### PR TITLE
Javascript variables are not being embedded into the page

### DIFF
--- a/collective/disqus/comments.py
+++ b/collective/disqus/comments.py
@@ -54,6 +54,11 @@ class CommentsViewlet(DisqusBaseViewlet):
         def to_string(key):
             return "var %s='%s';" % (key, str(vars[key]))
 
+        output = ''
+        for k in vars.keys():
+            output += to_string(k)
+        return output
+
 
 class CommentsCountViewlet(DisqusBaseViewlet):
     """ Viewlet that will display the number of comments """

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,8 +4,8 @@ Changelog
 2.0b2 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-- Nothing changed yet.
-
+- Bugfix, javascript variables weren't being embedded in the page.
+  [jcbrand]
 
 2.0b1 (2012-12-13)
 ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This bug caused the comments to not render at all (tested with Plone 4.1.6).
